### PR TITLE
Improved caching of api requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules
 
 # IDE
 .idea
+test.js
+.vscode/launch.json
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # homebridge-sengled (Beta)
 An unoffical [Homebridge](https://github.com/nfarina/homebridge) platform plugin for Sengled accessories.
 
+## Features for lamps:
+
+- State (on / off)
+- Hue (numeric value)
+- Brightness (numeric value)
+
+Note that I only have **Element Classic A19 Kit (Light bulbs + Hub)** to test.
+https://us.sengled.com/products/element-classic-kit  
+
 This plugin uses the existing Sengled Element Home app infrastructure to allow you to control your Sengled accessories.
 
 Provide your username and password and register as a platform, and it will auto-detect the light bulb you have registered.
-
-Note that I only have **Element Classic A19 Kit (Light bulbs + Hub)** to test  
-https://us.sengled.com/products/element-classic-kit  
 
 This plugin is still in beta.  
 If you encounter anything out of this product. Issue and Pull Request is welcome 🙂.
@@ -34,7 +40,9 @@ Configuration sample:
 
 ## Optional parameters
 
-- debug, this will enable more logging information from the plugin
+- debug, this will enable more logging information from the plugin, default = false
+- info, this will enable logging on api access from the plugin, default = true
+- cacheDuration, this will set the duration of the api call cache in seconds, default = 15 seconds
 
 ```
 "platforms": [
@@ -43,7 +51,9 @@ Configuration sample:
     "name": "SengledHub",
     "username": "***",
     "password": "***",
-    "debug": true
+    "debug": true,
+    "info": true,
+    "cacheDuration": 20000
   }
 ]
 ```

--- a/lib/client.js
+++ b/lib/client.js
@@ -3,6 +3,9 @@ const axiosCookieJarSupport = require('axios-cookiejar-support').default;
 const tough = require('tough-cookie');
 axiosCookieJarSupport(axios);
 const cookieJar = new tough.CookieJar();
+const _semaphore = require('semaphore')(1);
+
+
 
 let moment = require('moment');
 const https = require('https');
@@ -30,8 +33,13 @@ function _guid() {
 module.exports = class ElementHomeClient {
 
 
-
-	constructor(log, debug) {
+	/**
+	 * Ctor
+	 * @param {log} log Loggin Object
+	 * @param {boolean} debug Debug semaphore
+	 * @param {int} cacheDuration Duration of cache in milliseconds
+	 */
+	constructor(log, debug = false, info = true, cacheDuration = 2000, ) {
 
 		this.client = axios.create({
 			baseURL: 'https://element.cloud.sengled.com/zigbee/',
@@ -43,12 +51,15 @@ module.exports = class ElementHomeClient {
 		this.client.defaults.headers.post['Content-Type'] = 'application/json';
 		this.log = log
 		this.debug = debug
-		this.log("Starting Sengled Client...");
+		this.info = info
+		if (this.info) this.log("Starting Sengled Client...");
 		this.lastLogin = moment('2000-01-01')
 		this.uuid = _guid();
-		
-		this.cache = new Array();
+
+		this.cache = {};
 		this.lastCache = moment('2000-01-01')
+		this.cacheDuration = cacheDuration;
+		if (this.debug) this.log("set cache duration " + this.cacheDuration);
 	}
 
 	/**
@@ -57,29 +68,31 @@ module.exports = class ElementHomeClient {
 	login(username, password) {
 		let me = this;
 		if (me.debug) me.log("login invoked " + username);
-		
+		if (me.debug) me.log("login sessionid " + this.jsessionid);
+
 		return new Promise((fulfill, reject) => {
 			if (this.jsessionid != null) {
+				if (me.debug) me.log("login via cookie");
 				fulfill(this.loginResponse);
+			} else {
+				if (me.debug || me.info) me.log("login via api");
+				this.client.post('/customer/login.json', {
+					"os_type": "android",
+					"pwd": password,
+					"user": username,
+					"uuid": "xxxxxx"
+				}).then((response) => {
+					me.jsessionid = response.data.jsessionid;
+					me.lastLogin = moment();
+					me.loginResponse = response;
+					if (me.debug) me.log("logged in to Sengled");
+					fulfill(response);
+				}).catch(function (error) {
+					this.log(error);
+					reject(error);
+				});
 			}
-			this.client.post('/customer/login.json', {
-				"os_type": "android",
-				"pwd": password,
-				"user": username,
-				"uuid": "xxxxxx"
-			}).then((response) => {
-				this.jsessionid = response.data.jsessionid;
-				this.lastLogin = moment();
-				this.loginResponse = response;
-				fulfill(response);
-			}).catch(function(error) {
-				this.log(error);
-				reject(error);
-			});
-
 		});
-
-
 	}
 
 	/**
@@ -126,44 +139,60 @@ module.exports = class ElementHomeClient {
       * homebridge_1  |     rgbColorB: 255
       * homebridge_1  |   }
 	*/
-	getDevices() {
+	getDevices(cached = false) {
 		let me = this;
-		if (me.debug) me.log("getDevices invoked ");
-		if (me.debug) me.log(me.cache);
-		if (me.debug) me.log(moment() - me.lastCache);
-		if (moment() - me.lastCache <= 2000){
-			if (me.debug) me.log("######getDevices from cache ");
-			me.cache.map((device) => {return newDevice;});
-		}
-		
+		if (me.debug) me.log("getDevices invoked " + cached);
+		if (me.debug) me.log("cache size: " + Object.keys(me.cache).length);
+		if (me.debug) me.log("cache age: " + (moment() - me.lastCache));
+
 		return new Promise((fulfill, reject) => {
-			this.client.post('/room/getUserRoomsDetail.json', {})
-				.then((response) => {
-					if (response.data.ret == 100) {
-						reject(response.data);
-					} else {
-						let roomList = response.data.roomList
-						let deviceList = _ArrayFlatMap(roomList, i => i.deviceList);
-						let devices = deviceList.map((device) => {
-							var newDevice = {
-								id: device.deviceUuid,
-								name: device.deviceName,
-								status: device.onoff,
-								brightness: device.brightness,
-								colortemperature: device.colortemperature,
-								isOnline: device.isOnline,
-								signalQuality: device.signalQuality,
-								productCode: device.productCode
-							};
-							me.cache[newDevice.id] = newDevice;
-							me.lastCache = moment();
-							return newDevice;
+			_semaphore.take(() => {
+				if (moment() - me.lastCache <= me.cacheDuration || (cached && Object.keys(me.cache).length > 0)) {
+					if (me.debug) me.log("getDevices via cache ");
+					let devices = Object.keys(me.cache).map((deviceID) => {
+						let cachedDevice = me.cache[deviceID];
+						if (me.debug) me.log("cache device: " + JSON.stringify(cachedDevice));
+						return cachedDevice;
+					});
+					_semaphore.leave();
+					fulfill(devices);
+				} else {
+					if (me.debug || me.info) me.log("getDevices via api ");
+					this.client.post('/room/getUserRoomsDetail.json', {})
+						.then((response) => {
+							if (response.data.ret == 100) {
+								reject(response.data);
+							} else {
+								let roomList = response.data.roomList
+								let deviceList = _ArrayFlatMap(roomList, i => i.deviceList);
+								let devices = deviceList.map((device) => {
+									var apiDevice = {
+										id: device.deviceUuid,
+										name: device.deviceName,
+										status: device.onoff,
+										brightness: device.brightness,
+										colortemperature: device.colortemperature,
+										isOnline: device.isOnline,
+										signalQuality: device.signalQuality,
+										productCode: device.productCode
+									};
+									if (me.debug) me.log("api device: " + JSON.stringify(apiDevice));
+									me.cache[apiDevice.id] = apiDevice;
+									me.lastCache = moment();
+									return apiDevice;
+								});
+								_semaphore.leave();
+								fulfill(devices);
+							}
+						}).catch(function (error) {
+							_semaphore.leave();
+							reject(error);
+
 						});
-						fulfill(devices);
-					}
-				}).catch(function(error) {
-					reject(error);
-				});
+				}
+			});
+
+
 		});
 	}
 
@@ -178,7 +207,7 @@ module.exports = class ElementHomeClient {
 					} else {
 						fulfill(response);
 					}
-				}).catch(function(error) {
+				}).catch(function (error) {
 					reject(error);
 				});
 		});
@@ -200,7 +229,7 @@ module.exports = class ElementHomeClient {
 						fulfill(response);
 					}
 				})
-				.catch(function(error) {
+				.catch(function (error) {
 					reject(error);
 				});
 		});
@@ -223,7 +252,7 @@ module.exports = class ElementHomeClient {
 						fulfill(response);
 					}
 				})
-				.catch(function(error) {
+				.catch(function (error) {
 					reject(error);
 				});
 		});
@@ -246,7 +275,7 @@ module.exports = class ElementHomeClient {
 						fulfill(response);
 					}
 				})
-				.catch(function(error) {
+				.catch(function (error) {
 					reject(error);
 				});
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,8 @@
       "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-0.3.4.tgz",
       "integrity": "sha512-kvQMPfnlr9LKTYJ38L+7gT2tVcGY5dzJmhbwem4fSCUvfnmwnrT5yxR1LJQusQhaKRDEbDl7xX6AwcPbVJYBxg==",
       "requires": {
-        "@types/tough-cookie": "2.3.2",
-        "is-redirect": "1.0.0",
+        "@types/tough-cookie": "^2.3.1",
+        "is-redirect": "^1.0.0",
         "pify": "3.0.0",
         "tough-cookie": "2.3.3"
       }
@@ -75,12 +75,17 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
+    "semaphore": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
+      "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA=="
+    },
     "tough-cookie": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-sengled",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A unoffical Homebridge plugin for controlling sengled accessories.",
   "main": "index.js",
   "scripts": {
@@ -21,7 +21,8 @@
   "dependencies": {
     "axios": "^0.18.1",
     "axios-cookiejar-support": "^0.3.4",
-    "moment": "^2.20.1"
+    "moment": "^2.20.1",
+    "semaphore": "^1.1.0"
   },
   "keywords": [
     "siri",


### PR DESCRIPTION
added caching parameter for validity of api result => retrieved api response is cached and then reused a period of time. caching time can be adapted via cacheDuration config variable

added semaphore for api request, since the api requests for get state, get brightness, get hue are fired via promises and simultaniously. however the answer of each api request is enterly complete

Please push a new release to npm