### PR TITLE
Add devices found in deviceNoRoomList too

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -144,6 +144,7 @@ module.exports = class ElementHomeClient {
 					} else {
 						let roomList = response.data.roomList
 						let deviceList = _ArrayFlatMap(roomList, i => i.deviceList);
+						deviceList = deviceList.concat(response.data.deviceNoRoomList);
 						let devices = deviceList.map((device) => {
 							var newDevice = {
 								id: device.deviceUuid,


### PR DESCRIPTION
For some unknown reasons, my bulbs doesn't appear to be part of any room even if I moved them in a custom room from sengled app. For this reason the `roomList` list is empty and my devices are part of the `deviceNoRoomList` list.
This PR concatenate all devices found in both lists, `roomList` and `deviceNoRoomList`,  in `getDevices` method.
```
{
  "messageCode": "200",
  "info": "OK",
  "description": "正常",
  "roomList": [],
  "deviceNoRoomList": [
    {
      "deviceUuid": "B0CE18140354E284",
      "deviceName": "Black 1",
      "isOnline": 1,
      "onOff": 0,
      "productCode": "E11-G13"
    },
    {
      "deviceUuid": "B0CE181403103A9A",
      "deviceName": "Black 3",
      "isOnline": 1,
      "onOff": 1,
      "productCode": "E11-G13"
    },
    {
      "deviceUuid": "B0CE18140354E9D4",
      "deviceName": "Black 2",
      "isOnline": 1,
      "onOff": 0,
      "productCode": "E11-G13"
    }
  ],
  "deviceActiveHoursList": [
    {
      "deviceUuid": "B0CE18140354E284",
      "deviceName": "Black 1",
      "activeHours": 10051
    }
  ],
  "success": true
}
```